### PR TITLE
Fix error if a directory exists in the data directory

### DIFF
--- a/main.js
+++ b/main.js
@@ -216,6 +216,7 @@ define(function (require, exports, module) {
             
     //parse a JSON file with a snippet in it
     function loadSnippet(fileEntry) {
+        if(fileEntry.isDirectory) return;
         FileUtils.readAsText(fileEntry)
             .done(function (text, readTimestamp) {
                 try {


### PR DESCRIPTION
Error occurs if the directory exists in the data directory.

ex)

Directory structure

```
brackets-snippets
|- config.js
|- data
  |- some.json
  |- someDirectory
    |- some.snippet
```

some.json

```
[
    {
        "name": "somename",
        "trigger": "some",
        "usage": "some",
        "description": "snippet in sub directory",
        "template": "someDirectory/some.snippet"
    }
]
```

Thank you for providing a nice plugin!!
Thanks.
